### PR TITLE
Use PackageVersion for NuspecPath

### DIFF
--- a/BetterPackageReferences.targets
+++ b/BetterPackageReferences.targets
@@ -14,7 +14,7 @@
 
   <Target Name="PatchNuspecDependencies" AfterTargets="GenerateNuspec">
     <PropertyGroup>
-      <NuspecPath>$(NuspecOutputAbsolutePath)$(PackageId).$(Version).nuspec</NuspecPath>
+      <NuspecPath>$(NuspecOutputAbsolutePath)$(PackageId).$(PackageVersion).nuspec</NuspecPath>
     </PropertyGroup>
 
     <MSBuild


### PR DESCRIPTION
`Version` can be different from `PackageVersion`, which is ultimately what is used for the NuPkg